### PR TITLE
Requeue on reject

### DIFF
--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -168,7 +168,7 @@ Consumer.prototype.onMessage = function (callback) {
     callback(packet, function (err) {
       delete self.inbox[packet.id];
       if (err) {
-        msg.reject();
+        msg.reject(true);
       } else {
         msg.acknowledge();
       }


### PR DESCRIPTION
If a message fails to process properly, I'd prefer if the message didn't just get lost. Seems like that's what happens now. This commit makes messages get re-queued instead -- wondering what your opinions are?
