### PR TITLE
Queue consumers can be set up to point to a dead letter exchange

### DIFF
--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -24,7 +24,7 @@ module.exports = Consumer;
  * @constructor
  */
 
-function Consumer (starsky, name) {
+function Consumer (starsky, name, queueArgs) {
   this.starsky = starsky;
   this.name = snake(name);
   this.topics = [];
@@ -32,6 +32,7 @@ function Consumer (starsky, name) {
   this.tag = null;
   this.queue = null;
   this.options = { prefetch: 1 };
+  this.queueArgs = queueArgs || {};
   EventEmitter.call(this);
 }
 
@@ -95,7 +96,7 @@ Consumer.prototype.process = function (callback) {
 
   var name = this.name;
   var namespace = this.starsky.get('namespace');
-  var options = { durable: true, autoDelete: false };
+  var options = { durable: true, autoDelete: false, arguments: this.queueArgs };
 
   if (namespace) {
     name = namespace + ':' + name;

--- a/lib/starsky.js
+++ b/lib/starsky.js
@@ -172,8 +172,8 @@ Starsky.prototype.publish = function (topic, data, options, callback) {
  * @private
  */
 
-Starsky.prototype.consumer = function (name) {
-  return this.consumers[name] || (this.consumers[name] = new Consumer(this, name));
+Starsky.prototype.consumer = function (name, queueArgs) {
+  return this.consumers[name] || (this.consumers[name] = new Consumer(this, name, queueArgs));
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "jshint-stylish": "0.1.4",
     "mocha": "1.16.1",
     "jshint": "2.3.0",
-    "sinon": "1.7.3"
+    "sinon": "1.10.2"
   },
   "dependencies": {
     "amqp": "0.2.0",


### PR DESCRIPTION
Per discussion in #16, it would be awesome if there was a way to set this up in code. (The AMQP protocol supports this!)

What are your thoughts?

Thanks :)
