### PR TITLE
Bump AMQP version to 0.2.7, release 0.3.2, add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 [![Build Status](https://travis-ci.org/recurly/starsky.svg?branch=master)](https://travis-ci.org/recurly/starsky)
 
+# DEPRECATED
+
+This package is no longer actively maintained.
+
 # Starsky
 
 Starsky is a high-level, opinionated node module for writing services that consume messages from [RabbitMQ](https://www.rabbitmq.com/). It's modeled directly after the elegant approach taken by the Ruby library, [Hutch](https://github.com/gocardless/hutch). The opinions baked into the module are the same as Hutch's:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starsky",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A higher level and opinionated library on top of node-amqp.",
   "main": "index.js",
   "scripts": {
@@ -28,7 +28,7 @@
     "sinon": "1.10.2"
   },
   "dependencies": {
-    "amqp": "0.2.0",
+    "amqp": "0.2.7",
     "node-uuid": "1.4.1",
     "commander": "2.1.0",
     "debug": "0.7.4",


### PR DESCRIPTION
* Bumps AMQP from 0.2.0 to 0.2.7
* Bumps package version to 0.3.2
* Adds deprecation warning to the readme